### PR TITLE
Including Patient as part of url for search

### DIFF
--- a/simple-search.html
+++ b/simple-search.html
@@ -128,7 +128,7 @@
                         <p>Perform this search in your Postman client using he Http verb <b>GET</b> now, take a few minutes to examine the result returned:</p>
 
 
-                        <p><code id="fhir-server"></code><b><code>?family=fhirman</code></b></p>
+                        <p><code id="fhir-server"></code><code>/Patient<b>?family=fhirman</b></code></p>
 
                         <p>Did you notice that you received a <b>Bundle</b> resource in return? When you perform a search you are more than likely to receive many resource matching your search. In FHIR, search results are always returned as a <b>Bundle</b>. A <b>Bundle</b> is used in FHIR to gather a collection of resource into a single instance. The reason there are so many <b>Mr Sam Fhirman</b> Patient resources is due to every student taking part in the <a href="./simple-patient.html">Simple Patient</a> tutorial uploading their own instance of the same patient. <i>This may explain why our PAS team is so busy with duplicate patient merging.</i> Of course this should not be the case in the real world. <i>Although the PAS team may have another opinion.</i></p>
 


### PR DESCRIPTION
Hi there - was just going through the exercises and noticed that the patient search didn't function as advertised. I've added the missing 'Patient' resource name at the end of the url.

Thanks for putting this together - great set of exercises!

Cheers, jgw